### PR TITLE
Log exception stacktraces as a single loggregator log message 

### DIFF
--- a/springboottrades-accounts/src/main/resources/logback.xml
+++ b/springboottrades-accounts/src/main/resources/logback.xml
@@ -1,0 +1,1 @@
+/workspaces/mrdavidlaing/src/cf-SpringBootTrader/springboottrades-quotes/src/main/resources/logback.xml

--- a/springboottrades-portfolio/src/main/resources/logback.xml
+++ b/springboottrades-portfolio/src/main/resources/logback.xml
@@ -1,0 +1,1 @@
+/workspaces/mrdavidlaing/src/cf-SpringBootTrader/springboottrades-quotes/src/main/resources/logback.xml

--- a/springboottrades-quotes/src/main/java/io/pivotal/quotes/controller/QuoteController.java
+++ b/springboottrades-quotes/src/main/java/io/pivotal/quotes/controller/QuoteController.java
@@ -10,6 +10,9 @@ import io.pivotal.quotes.domain.Quote;
 import io.pivotal.quotes.exception.SymbolNotFoundException;
 import io.pivotal.quotes.service.QuoteService;
 
+import org.slf4j.MDC;
+import java.util.UUID;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,6 +53,7 @@ public class QuoteController {
 	 */
 	@RequestMapping(value = "/quote/{symbol}", method = RequestMethod.GET)
 	public ResponseEntity<Quote> getQuote(@PathVariable("symbol") final String symbol) throws SymbolNotFoundException {
+		setCorrelationIds();
 		logger.debug("QuoteController.getQuote: retrieving quote for: " + symbol);
 		Quote quote = service.getQuote(symbol);
 		logger.info(String.format("Retrieved symbol: %s with quote %s", symbol, quote));
@@ -65,6 +69,7 @@ public class QuoteController {
 	 */
 	@RequestMapping(value = "/company/{name}", method = RequestMethod.GET)
 	public ResponseEntity<List<CompanyInfo>> getCompanies(@PathVariable("name") final String name) {
+		setCorrelationIds();
 		logger.debug("QuoteController.getCompanies: retrieving companies for: " + name);
 		List<CompanyInfo> companies = service.getCompanyInfo(name);
 		logger.info(String.format("Retrieved companies with search parameter: %s - list: {}", name), companies);
@@ -82,6 +87,13 @@ public class QuoteController {
 	}
 	
 	/**
+	 * Mock what spring-cloud-sleuth does 
+	 */
+	private void setCorrelationIds() {
+                MDC.put("X-Span-Id", UUID.randomUUID().toString());
+                MDC.put("X-Trace-Id", UUID.randomUUID().toString());
+	}	
+	/**
 	 * Handles the response to the client if there is any exception during the processing of HTTP requests.
 	 * 
 	 * @param e The exception thrown during the processing of the request.
@@ -90,9 +102,9 @@ public class QuoteController {
 	 */
 	@ExceptionHandler({Exception.class})
 	public void handleException(Exception e, HttpServletResponse response) throws IOException {
-		logger.warn("Handle Error: " + e.getMessage());
-		e.printStackTrace();
+		logger.warn("Handle Error: ", e);
 		response.sendError(HttpStatus.BAD_REQUEST.value(), "ERROR: " + e.getMessage());
 	    //return "ERROR: " + e.getMessage();
 	}
+
 }

--- a/springboottrades-quotes/src/main/java/io/pivotal/quotes/controller/QuoteController.java
+++ b/springboottrades-quotes/src/main/java/io/pivotal/quotes/controller/QuoteController.java
@@ -10,9 +10,6 @@ import io.pivotal.quotes.domain.Quote;
 import io.pivotal.quotes.exception.SymbolNotFoundException;
 import io.pivotal.quotes.service.QuoteService;
 
-import org.slf4j.MDC;
-import java.util.UUID;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -53,7 +50,6 @@ public class QuoteController {
 	 */
 	@RequestMapping(value = "/quote/{symbol}", method = RequestMethod.GET)
 	public ResponseEntity<Quote> getQuote(@PathVariable("symbol") final String symbol) throws SymbolNotFoundException {
-		setCorrelationIds();
 		logger.debug("QuoteController.getQuote: retrieving quote for: " + symbol);
 		Quote quote = service.getQuote(symbol);
 		logger.info(String.format("Retrieved symbol: %s with quote %s", symbol, quote));
@@ -69,7 +65,6 @@ public class QuoteController {
 	 */
 	@RequestMapping(value = "/company/{name}", method = RequestMethod.GET)
 	public ResponseEntity<List<CompanyInfo>> getCompanies(@PathVariable("name") final String name) {
-		setCorrelationIds();
 		logger.debug("QuoteController.getCompanies: retrieving companies for: " + name);
 		List<CompanyInfo> companies = service.getCompanyInfo(name);
 		logger.info(String.format("Retrieved companies with search parameter: %s - list: {}", name), companies);
@@ -87,13 +82,6 @@ public class QuoteController {
 	}
 	
 	/**
-	 * Mock what spring-cloud-sleuth does 
-	 */
-	private void setCorrelationIds() {
-                MDC.put("X-Span-Id", UUID.randomUUID().toString());
-                MDC.put("X-Trace-Id", UUID.randomUUID().toString());
-	}	
-	/**
 	 * Handles the response to the client if there is any exception during the processing of HTTP requests.
 	 * 
 	 * @param e The exception thrown during the processing of the request.
@@ -104,7 +92,6 @@ public class QuoteController {
 	public void handleException(Exception e, HttpServletResponse response) throws IOException {
 		logger.warn("Handle Error: ", e);
 		response.sendError(HttpStatus.BAD_REQUEST.value(), "ERROR: " + e.getMessage());
-	    //return "ERROR: " + e.getMessage();
 	}
 
 }

--- a/springboottrades-quotes/src/main/resources/logback.xml
+++ b/springboottrades-quotes/src/main/resources/logback.xml
@@ -1,0 +1,57 @@
+<configuration>
+	<conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
+	<conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+
+	<property name="CONSOLE_LOG_PATTERN" value="%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%replace(%xException){'\n','&#x2028;'}%nopex%n"/>
+	<property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} %5p ${PID:- } --- [%t] %-40.40logger{39} : %m%n%wex"/>
+
+	<appender name="DEBUG_LEVEL_REMAPPER" class="org.springframework.boot.logging.logback.LevelRemappingAppender">
+		<destinationLogger>org.springframework.boot</destinationLogger>
+	</appender>
+
+	<logger name="org.apache.catalina.startup.DigesterFactory" level="ERROR"/>
+	<logger name="org.apache.catalina.util.LifecycleBase" level="ERROR"/>
+	<logger name="org.apache.coyote.http11.Http11NioProtocol" level="WARN"/>
+	<logger name="org.apache.sshd.common.util.SecurityUtils" level="WARN"/>
+	<logger name="org.apache.tomcat.util.net.NioSelectorPool" level="WARN"/>
+	<logger name="org.crsh.plugin" level="WARN"/>
+	<logger name="org.crsh.ssh" level="WARN"/>
+	<logger name="org.eclipse.jetty.util.component.AbstractLifeCycle" level="ERROR"/>
+	<logger name="org.hibernate.validator.internal.util.Version" level="WARN"/>
+	<logger name="org.springframework.boot.actuate.autoconfigure.CrshAutoConfiguration" level="WARN"/>
+	<logger name="org.springframework.boot.actuate.endpoint.jmx" additivity="false">
+		<appender-ref ref="DEBUG_LEVEL_REMAPPER"/>
+	</logger>
+	<logger name="org.thymeleaf" additivity="false">
+		<appender-ref ref="DEBUG_LEVEL_REMAPPER"/>
+	</logger>
+
+	<property name="LOG_FILE" value="${LOG_FILE:-${LOG_PATH:-${LOG_TEMP:-${java.io.tmpdir:-/tmp}}/}spring.log}"/>
+
+	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>${CONSOLE_LOG_PATTERN}</pattern>
+			<charset>utf8</charset>
+		</encoder>
+	</appender>
+
+	<appender name="FILE"
+		class="ch.qos.logback.core.rolling.RollingFileAppender">
+		<encoder>
+			<pattern>${FILE_LOG_PATTERN}</pattern>
+		</encoder>
+		<file>${LOG_FILE}</file>
+		<rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+			<fileNamePattern>${LOG_FILE}.%i</fileNamePattern>
+		</rollingPolicy>
+		<triggeringPolicy
+			class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+			<MaxFileSize>10MB</MaxFileSize>
+		</triggeringPolicy>
+	</appender>
+
+	<root level="INFO">
+		<appender-ref ref="CONSOLE" />
+		<appender-ref ref="FILE" />
+	</root>
+</configuration>

--- a/springboottrades-web/src/main/java/io/pivotal/web/controller/PortfolioController.java
+++ b/springboottrades-web/src/main/java/io/pivotal/web/controller/PortfolioController.java
@@ -53,12 +53,11 @@ public class PortfolioController {
 
 	@ExceptionHandler({ Exception.class })
 	public ModelAndView error(HttpServletRequest req, Exception exception) {
-		logger.debug("Handling error: " + exception);
+		logger.warn("Handling error: ", exception);
 		ModelAndView model = new ModelAndView();
 		model.addObject("errorCode", exception.getMessage());
 		model.addObject("errorMessage", exception);
 		model.setViewName("error");
-		exception.printStackTrace();
 		return model;
 	}
 

--- a/springboottrades-web/src/main/java/io/pivotal/web/controller/TradeController.java
+++ b/springboottrades-web/src/main/java/io/pivotal/web/controller/TradeController.java
@@ -137,12 +137,11 @@ public class TradeController {
 	
 	@ExceptionHandler({ Exception.class })
 	public ModelAndView error(HttpServletRequest req, Exception exception) {
-		logger.debug("Handling error: " + exception);
+		logger.warn("Handling error: ", exception);
 		ModelAndView model = new ModelAndView();
 		model.addObject("errorCode", exception.getMessage());
 		model.addObject("errorMessage", exception);
 		model.setViewName("error");
-		exception.printStackTrace();
 		return model;
 	}
 }

--- a/springboottrades-web/src/main/java/io/pivotal/web/controller/UserController.java
+++ b/springboottrades-web/src/main/java/io/pivotal/web/controller/UserController.java
@@ -112,12 +112,11 @@ public class UserController {
 	}
 	@ExceptionHandler({ Exception.class })
 	public ModelAndView error(HttpServletRequest req, Exception exception) {
-		logger.debug("Handling error: " + exception);
+		logger.warn("Handling error: ", exception);
 		ModelAndView model = new ModelAndView();
 		model.addObject("errorCode", exception.getMessage());
 		model.addObject("errorMessage", exception);
 		model.setViewName("error");
-		exception.printStackTrace();
 		return model;
 	}
 }

--- a/springboottrades-web/src/main/resources/logback.xml
+++ b/springboottrades-web/src/main/resources/logback.xml
@@ -1,0 +1,1 @@
+/workspaces/mrdavidlaing/src/cf-SpringBootTrader/springboottrades-quotes/src/main/resources/logback.xml


### PR DESCRIPTION
Log messages split over several lines (such as Java Exception stacktraces) get split into multiple messages by Cloud Foundry's loggregator.

Its nearly impossible to reassemble these related lines into a single line in a log aggregation system (like logstash), because the order of the logs can get mixed up.

This PR extends spring boot's default logback configuration so that exceptions are logged using the unicode newline character (u2028) rather than `\n`; causing loggregator to group all the stack trace lines in a single log message.

In the downstream log processor [it is reasonably simple to convert u2028 back to `\n`](https://github.com/logsearch/logsearch-for-cloudfoundry/commit/859a5337ab17842ee05484ca73c8f61f1cf908f5#diff-b6d1c58db907ddd6eed754c7dd480679), resulting in readable stack traces in UIs like Kibana:

<img width="1384" alt="screen shot 2015-08-20 at 09 20 36" src="https://cloud.githubusercontent.com/assets/227505/9379611/6fbfd686-4722-11e5-8f0f-35346b3a8ede.png">
