### PR TITLE
Log exception stacktraces as a single loggregator log message

### DIFF
--- a/registryServer/src/main/resources/application.yml
+++ b/registryServer/src/main/resources/application.yml
@@ -32,6 +32,9 @@ spring:
 eureka:
   instance:
     nonSecurePort: 80  
+logging:
+  pattern:
+    console: "%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} %clr(---){faint} %clr([trace=%X{X-Trace-Id:-},span=%X{X-Span-Id:-}]){yellow} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%replace(%xException){'\n','\u2028'}%nopex%n"
 #server:
 #  port: ${vcap.application.port:80}
 --- 

--- a/springboottrades-accounts/src/main/resources/application.yml
+++ b/springboottrades-accounts/src/main/resources/application.yml
@@ -30,7 +30,7 @@ eureka:
      nonSecurePort: 80
 logging:
   pattern:
-    console: '%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} %clr(---){faint} %clr([trace=%X{X-Trace-Id:-},span=%X{X-Span-Id:-}]){yellow} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'     
+    console: "%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} %clr(---){faint} %clr([trace=%X{X-Trace-Id:-},span=%X{X-Span-Id:-}]){yellow} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%replace(%xException){'\n','\u2028'}%nopex%n"
 ---        
 logging:
   level:

--- a/springboottrades-portfolio/src/main/resources/application.yml
+++ b/springboottrades-portfolio/src/main/resources/application.yml
@@ -33,7 +33,7 @@ eureka:
     nonSecurePort: 80
 logging:
   pattern:
-    console: '%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} %clr(---){faint} %clr([trace=%X{X-Trace-Id:-},span=%X{X-Span-Id:-}]){yellow} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'    
+    console: "%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} %clr(---){faint} %clr([trace=%X{X-Trace-Id:-},span=%X{X-Span-Id:-}]){yellow} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%replace(%xException){'\n','\u2028'}%nopex%n"
 ---        
 logging:
   level:

--- a/springboottrades-quotes/src/main/resources/application.yml
+++ b/springboottrades-quotes/src/main/resources/application.yml
@@ -30,7 +30,7 @@ eureka:
     nonSecurePort: 80
 logging:
   pattern:
-    console: '%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} %clr(---){faint} %clr([trace=%X{X-Trace-Id:-},span=%X{X-Span-Id:-}]){yellow} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'
+    console: "%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} %clr(---){faint} %clr([trace=%X{X-Trace-Id:-},span=%X{X-Span-Id:-}]){yellow} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%replace(%xException){'\n','\u2028'}%nopex%n"
 ---        
 logging:
   level:

--- a/springboottrades-web/src/main/resources/application.yml
+++ b/springboottrades-web/src/main/resources/application.yml
@@ -34,7 +34,7 @@ eureka:
     nonSecurePort: 80
 logging:
   pattern:
-    console: '%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} %clr(---){faint} %clr([trace=%X{X-Trace-Id:-},span=%X{X-Span-Id:-}]){yellow} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'
+    console: "%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} %clr(---){faint} %clr([trace=%X{X-Trace-Id:-},span=%X{X-Span-Id:-}]){yellow} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%replace(%xException){'\n','\u2028'}%nopex%n"
 ---        
 logging:
   level:


### PR DESCRIPTION
Log messages split over several lines (such as Java Exception stacktraces) get split into multiple messages by Cloud Foundry's loggregator.

Its nearly impossible to reassemble these related lines into a single line in a log aggregation system (like logstash), because the order of the logs can get mixed up.

This PR extends spring boot's default logback configuration so that exceptions are logged using the unicode newline character (u2028) rather than `\n`; causing loggregator to group all the stack trace lines in a single log message.

In the downstream log processor [it is reasonably simple to convert u2028 back to `\n`](https://github.com/logsearch/logsearch-for-cloudfoundry/commit/859a5337ab17842ee05484ca73c8f61f1cf908f5#diff-b6d1c58db907ddd6eed754c7dd480679), resulting in readable stack traces in UIs like Kibana:

<img width="1384" alt="screen shot 2015-08-20 at 09 20 36" src="https://cloud.githubusercontent.com/assets/227505/9379611/6fbfd686-4722-11e5-8f0f-35346b3a8ede.png">

----
This PR replaces https://github.com/dpinto-pivotal/cf-SpringBootTrader/pull/10