### PR TITLE
Fix OOM errors

### DIFF
--- a/springboottrades-accounts/manifest-unversioned.yml
+++ b/springboottrades-accounts/manifest-unversioned.yml
@@ -1,7 +1,7 @@
 ---
 timeout: 180
 instances: 1
-memory: 512M
+memory: 768M
 env:
     SPRING_PROFILES_ACTIVE: cloud
     JAVA_OPTS: -Djava.security.egd=file:///dev/urandom

--- a/springboottrades-portfolio/manifest-unversioned.yml
+++ b/springboottrades-portfolio/manifest-unversioned.yml
@@ -1,7 +1,7 @@
 ---
 timeout: 180
 instances: 1
-memory: 512M
+memory: 768M
 env:
     SPRING_PROFILES_ACTIVE: cloud
     JAVA_OPTS: -Djava.security.egd=file:///dev/urandom

--- a/springboottrades-quotes/manifest-unversioned.yml
+++ b/springboottrades-quotes/manifest-unversioned.yml
@@ -1,7 +1,7 @@
 ---
 timeout: 180
 instances: 1
-memory: 512M
+memory: 768M
 env:
     SPRING_PROFILES_ACTIVE: cloud
     JAVA_OPTS: -Djava.security.egd=file:///dev/urandom

--- a/springboottrades-web/manifest-unversioned.yml
+++ b/springboottrades-web/manifest-unversioned.yml
@@ -1,7 +1,7 @@
 ---
 timeout: 180
 instances: 1
-memory: 512M
+memory: 768M
 env:
     SPRING_PROFILES_ACTIVE: cloud
     JAVA_OPTS: -Djava.security.egd=file:///dev/urandom


### PR DESCRIPTION
I used this in a classroom recently for a PCF on Azure workshop (25 students deploying this -- 200 AIs if you count all the backing SCS services and 50 mySQL instances,!) and was seeing various out of memory errors pop up on every service as you use the app, which would be restarted by Diego.   

The UX is to get a 502 error temporarily while the app drops out of the CF router (assuming you're only running 1 instance).

Bumping the RAM to 768M may make this less susceptible to OOM crashes 