### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Microservice version of the Spring Trader app using spring boot
 
 ![Spring Trader](/docs/springtrader2.png)
 
-#Introduction
+# Introduction
 
 This repository holds a collection of micro services that work together to present a trading application surfaced though a web UI, but more interfaces can be created that re-utilise the microservices.
 
@@ -14,7 +14,7 @@ It was created to support workshops and demonstrations of building and using `mi
 
 The workshops follow a series of exercises, or labs, and you can find links to the guides for these exercises [below](#workshops).
 
-##Table of Contents
+## Table of Contents
 
 1. [Architecture](#architecture)
 2. [Deploying the application](#deployment)
@@ -24,12 +24,12 @@ The workshops follow a series of exercises, or labs, and you can find links to t
 6. [Contributing to the project](#contributing)
 
 
-#Architecture
+# Architecture
 The system is composed of 4 microservices. The relationship between the microservices is illustrated below.
 
 ![architecture](/docs/microservices_relationship.png)
 
-##1. Quote Microservice
+## 1. Quote Microservice
 This service is a spring boot application responsible for providing up to date company and ticker/quote information. It does this by providing a REST api with 2 calls:
 * ``/quotes?q={symbols}``
 Returns an up to date quote for each symbol in the comma-delimited list.
@@ -38,19 +38,19 @@ Returns a list of companies that have the search parameter in their names or sym
 
 This application has no dependencies apart from an external service - [markitondemand](http://dev.markitondemand.com/) - to retrieve the real time data.
 
-##2. Account Microservice
+## 2. Account Microservice
 This service is a spring boot application responsible for creating and managing user accounts.
 
 It stores the accounts in a RDBMS store and uses a spring JPA respository to accomplish this. It provides several REST api calls for other services to consume its services.
 
-##3. Portfolio Microservice
+## 3. Portfolio Microservice
 This service is a spring boot application responsible for managing portfolios - these are collections of holdings, which in turn are collection of orders on a particular share.
 
 This service accepts orders (both BUY and SELL) and stores these in a RDBMS store - *it does not have to be the same RDBMS as the Account service, but it can be!* It provides REST api calls for other services to consume its services.
 
 This service is dependent on the Account service above to ensure the logged in user has enough funds to buy stock as well as keeping the account funds up to date. It is also dependent on the Quote service to retrieve up to date quote information and calculate the current value of portfolios.
 
-##4. Web Microservice
+## 4. Web Microservice
 This service is a spring boot application providing the web interface.
 
 The web interface is built using bootstrap and Thymeleaf and uses a Spring controller to delegate calls to the relevant services:
@@ -58,7 +58,7 @@ The web interface is built using bootstrap and Thymeleaf and uses a Spring contr
 * Quote service
 * Portfolio service
 
-#Deployment
+# Deployment
 
 To deploy the microservices please follow the guides of the [workshop below](#workshops).
 
@@ -68,7 +68,7 @@ Each guide includes instructions on how to deploy and run to:
   - [Pivotal Web Services](http://run.pivotal.io)
   - local machine.
 
-#Workshops:
+# Workshops:
 
 The following guides describe how to setup the environment and deploy the microservices to **Cloud Foundry**.
 
@@ -95,35 +95,35 @@ At Pivotal we love education, not just educating ourselves, but also educating o
 [scale]: docs/lab_scale.md
 [bluegreen]: docs/lab_bluegreen.md
 
-#Demos
+# Demos
 
-###1. Deploying to **Pivotal Cloud Foundry**.
+### 1. Deploying to **Pivotal Cloud Foundry**.
 TODO: document a walk through of this demo. This is a walkthough of the workshop above.
 - Deploying microservices to Cloud Foundry.
 - Creating and binding services to applications.
 
-###2. Service discovery.
+### 2. Service discovery.
 TODO: document a walk through of this demo.
 
-###3. Scalability
+### 3. Scalability
 TODO: document a walk through of this demo.
 - provide a load generator to mimic users.
 - scale instances.
 
-###4. Configuration Management.
+### 4. Configuration Management.
 TODO: document a walk through of this demo.
 
-###5. Traceability across all services.
+### 5. Traceability across all services.
 TODO: document a walk through of this demo using Zipkin and Kibana.
 
-###6. Continuous Integration/Continuous Delivery.
+### 6. Continuous Integration/Continuous Delivery.
 TODO: document a walk through of this demo.
 
-###7. Operations Demo
+### 7. Operations Demo
 TODO: document how to operate/monitor several microservices, using Spring Boot Admin and ELK tile
 
 
-#Features
+# Features
 
 - **Discovery service:**
   All microservices register with the [Discovery Service](http://cloud.spring.io/spring-cloud-netflix/spring-cloud-netflix.html) and discover other microservices through it.
@@ -132,7 +132,7 @@ TODO: document how to operate/monitor several microservices, using Spring Boot A
 - **Config Server:**
   The microservices obtain the configuration from a [Configuration Service](http://cloud.spring.io/spring-cloud-config/) backed by a git repository. This means that configuration is now auditables and version controlled, as well as providing the ability to refresh configuration during runtime.
 
-#Roadmap
+# Roadmap
 
 The roadmap for this project is constantly evolving. Please feel free to reach out with ideas.
 - **Better APIs:**
@@ -150,7 +150,7 @@ The roadmap for this project is constantly evolving. Please feel free to reach o
 - **Mobile UI:**
   Mobile interface to expose the services on an iOS device and/or Android device natively, making use of the [Pivotal Cloud Foundry Mobile Services](http://docs.pivotal.io/mobile/index.html).
 
-#Contributing
+# Contributing
 Everyone is encouraged to help improved this project.
 
 The master branch has the latest stable release. development happens in the development branch (or feature branches that get merged into development branch). So please check if want you to develop is already in the development branch.
@@ -165,11 +165,11 @@ Here are some ways you can contribute:
 - by refactoring code
 - by closing [issues](https://github.com/dpinto-pivotal/cf-SpringBootTrader/issues)
 
-##Submitting an Issue
+## Submitting an Issue
 
 We use the [GitHub issue tracker](https://github.com/dpinto-pivotal/cf-SpringBootTrader/issues) to track bugs and features. Before submitting a bug report or feature request, check to make sure it hasn't already been submitted. When submitting a bug report, please include any relevant information. Ideally, a bug report should include a pull request with failing specs, and maybe even a fix!
 
-##Submitting a Pull Request
+## Submitting a Pull Request
 
 1. Fork the project.
 2. Create a topic branch.

--- a/docs/lab_circuitbreaker.md
+++ b/docs/lab_circuitbreaker.md
@@ -32,7 +32,7 @@ When prompted for the name of the service, insert **"circuit-breaker-dashboard"*
 
 > You can pick any name of the service, however, the service is already specified in the manifest files, so it is easier to re-use that name. If you do modify the name, ensure you modify it in the manifest files as well.
 
-##Deploying without Spring Cloud Services
+## Deploying without Spring Cloud Services
 If the cloud does not provide us with the services, then we can deploy the services ourselves. Bare in mind that our deployment of the Circuit Breaker Dashboard Service will not be highly available or load balanced.
 
 Follow the guidelines to deploy the Discover service [here](https://github.com/dpinto-pivotal/cf-SpringBootTrader-extras) - TODO!
@@ -53,7 +53,7 @@ In order for our microservices to be able to connect to the Circuit breaker dash
 
   > Do **not** specify the protocol!!! ie. "http://"
 
-##Running it locally
+## Running it locally
 If you want to run all the services locally, you'll need to start the circuit breaker dashboard service.
 
 Follow the guidelines to run the Discover service locally  [here](https://github.com/dpinto-pivotal/cf-SpringBootTrader-extras).

--- a/docs/lab_configserver.md
+++ b/docs/lab_configserver.md
@@ -16,7 +16,7 @@ When prompted for the name of the service, insert **"config-server"** and bind i
 
 2. Click on *Manage* for the service you created to open the service dashboard. It will prompt you to enter either a Git or Subversion URI. Choose Git and enter **https://github.com/dpinto-pivotal/cf-SpringBootTrader-config.git** as the URI.
 
-##Deploying without Spring Cloud Services
+## Deploying without Spring Cloud Services
 If the cloud does not provide us with the services, then we can deploy the services ourselves. Bare in mind that our deployment of the Config Service will not be highly available or load balanced.
 
 Follow the guidelines to deploy the Config service [here](https://github.com/dpinto-pivotal/cf-SpringBootTrader-extras).
@@ -36,7 +36,7 @@ In order for our microservices to be able to connect to the Registry service, we
 
     If you are deploying the services to multiple [spaces](http://docs.pivotal.io/pivotalcf/concepts/roles.html#spaces), then you must create the user-provided service in each space.
 
-##Running it locally
+## Running it locally
 If you want to run all the services locally, you'll need to start the discovery service.
 
 Follow the guidelines to run the Discover service locally  [here](https://github.com/dpinto-pivotal/cf-SpringBootTrader-extras).

--- a/docs/lab_pushall.md
+++ b/docs/lab_pushall.md
@@ -64,7 +64,7 @@ Now that we have all the required services created, let's push all the services.
 
 Once completed, go to the URL of the Web service in your browser.
 
-##Deploying without Spring Cloud Services
+## Deploying without Spring Cloud Services
 
   If Spring Cloud Services are not available, you should have pushed an instance of the [discovery service](https://github.com/dpinto-pivotal/cf-SpringBootTrader-extras) to the cloud and you should already have a [*User-provided service*](http://docs.pivotal.io/pivotalcf/devguide/services/user-provided.html).
 
@@ -73,7 +73,7 @@ Once completed, go to the URL of the Web service in your browser.
   ### Exercise
     1. push the applications
 
-##Running it locally
+## Running it locally
   To run the service locally, you can use the gradle wrapper script as such:
 
   ```

--- a/docs/lab_pushquote.md
+++ b/docs/lab_pushquote.md
@@ -37,7 +37,7 @@ Luckily, Pivotal Cloud Foundry allows us to assign a [`random-route`](http://doc
 
   > IMPORTANT: The Starters for Spring Cloud Services has a dependency on Spring Security, and by default, this will cause all client application endpoints to be protected by HTTP Basic authentication. You can disable this; see ["Disable HTTP Basic Authentication"](http://docs.pivotal.io/spring-cloud-services/service-registry/registering-a-service.html#disable-http-basic-auth) in the [Spring Cloud Services documentation for Service Registry](http://docs.pivotal.io/spring-cloud-services/service-registry/).
 
-##Deploying without Spring Cloud Services
+## Deploying without Spring Cloud Services
 
   If Spring Cloud Services are not available, you should have pushed an instance of the [discovery service](https://github.com/dpinto-pivotal/cf-SpringBootTrader-extras) to the cloud. Now, you'll have to create a [*User-provided service*](http://docs.pivotal.io/pivotalcf/devguide/services/user-provided.html) and bind it to the quote service.
 
@@ -55,7 +55,7 @@ Luckily, Pivotal Cloud Foundry allows us to assign a [`random-route`](http://doc
 
     2. push the application
 
-##Running it locally
+## Running it locally
   To run the quote service locally, you can use the gradle wrapper script as such:
 
   ```

--- a/docs/lab_registryserver.md
+++ b/docs/lab_registryserver.md
@@ -15,7 +15,7 @@ When prompted for the name of the service, insert **"discovery-service"** and bi
 
 > You can pick any name of the service, however, the service is already specified in the manifest files, so it is easier to re-use that name. If you do modify the name, ensure you modify it in the manifest files as well.
 
-##Deploying without Spring Cloud Services
+## Deploying without Spring Cloud Services
 If the cloud does not provide us with the services, then we can deploy the services ourselves. Bare in mind that our deployment of the Discovery Service will not be highly available or load balanced.
 
 Follow the guidelines to deploy the Discover service [here](https://github.com/dpinto-pivotal/cf-SpringBootTrader-extras).
@@ -38,7 +38,7 @@ In order for our microservices to be able to connect to the Registry service, we
 
     If you are deploying the services to multiple [spaces](http://docs.pivotal.io/pivotalcf/concepts/roles.html#spaces), then you must create the user-provided service in each space.
 
-##Running it locally
+## Running it locally
 If you want to run all the services locally, you'll need to start the discovery service.
 
 Follow the guidelines to run the Discover service locally  [here](https://github.com/dpinto-pivotal/cf-SpringBootTrader-extras).

--- a/docs/lab_setup.md
+++ b/docs/lab_setup.md
@@ -1,4 +1,4 @@
-#Setting up the environment.
+# Setting up the environment.
 In this exercise, we will be setting up the environment and all the tools required.
 
 It assumes you are running Linux or MacOS, although it is possible to configure on Windows too.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
