### PR TITLE
A better suggestion about the annotation usage

### DIFF
--- a/springboottrades-web/src/main/java/io/pivotal/web/security/CustomCredentialsService.java
+++ b/springboottrades-web/src/main/java/io/pivotal/web/security/CustomCredentialsService.java
@@ -14,9 +14,9 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
-@Component
+@Service
 public class CustomCredentialsService implements UserDetailsService {
 
 	private static final Logger logger = LoggerFactory.getLogger(CustomCredentialsService.class);


### PR DESCRIPTION
Hi, I found that there may be some minor improvements about annotations in your code.

A Spring bean in the service layer should be annotated using @service instead of @component annotation.
@service annotation is a specialization of @component in service layer. By using a specialized annotation we hit two birds with one stone. First, they are treated as Spring bean, and second, you can put special behavior required by that layer.

For better understanding and maintainability of a large application, @service is a better choice.